### PR TITLE
ffmpeg compiler flag for video understanding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ option(LLAMA_BUILD_SERVER   "llama: build server example" ${LLAMA_STANDALONE})
 
 # 3rd party libs
 option(LLAMA_CURL "llama: use libcurl to download model from an URL" OFF)
+option(LLAMA_FFMPEG "llama: use ffmpeg to load video files" OFF)
 
 # Required for relocatable CMake package
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/build-info.cmake)

--- a/Makefile
+++ b/Makefile
@@ -968,6 +968,11 @@ override CXXFLAGS := $(CXXFLAGS) -DLLAMA_USE_CURL
 override LDFLAGS  := $(LDFLAGS) -lcurl
 endif
 
+ifdef LLAMA_FFMPEG
+override CXXFLAGS := $(CXXFLAGS) -DLLAMA_USE_FFMPEG $(shell pkg-config --cflags libavformat libavcodec libavutil)
+override LDFLAGS  := $(LDFLAGS) $(shell pkg-config --libs libavformat libavcodec libavutil) -lswscale
+endif
+
 #
 # Print build information
 #
@@ -1465,16 +1470,13 @@ llama-llava-cli: examples/llava/llava-cli.cpp \
 	$(OBJ_ALL)
 	$(CXX) $(CXXFLAGS) $< $(filter-out %.h $<,$^) -o $@ $(LDFLAGS) -Wno-cast-qual
 
-FFMPEG_CFLAGS := $(shell pkg-config --cflags libavformat libavcodec libavutil)
-FFMPEG_LIBS := $(shell pkg-config --libs libavformat libavcodec libavutil) -lswscale
-
 llama-minicpmv-cli: examples/llava/minicpmv-cli.cpp \
 	examples/llava/llava.cpp \
 	examples/llava/llava.h \
 	examples/llava/clip.cpp \
 	examples/llava/clip.h \
 	$(OBJ_ALL)
-	$(CXX) $(CXXFLAGS) $(FFMPEG_CFLAGS) $< $(filter-out %.h $<,$^) -o $@ $(LDFLAGS) $(FFMPEG_LIBS) -Wno-cast-qual
+	$(CXX) $(CXXFLAGS) $< $(filter-out %.h $<,$^) -o $@ $(LDFLAGS) -Wno-cast-qual
 
 ifeq ($(UNAME_S),Darwin)
 swift: examples/batched.swift

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -83,6 +83,19 @@ if (LLAMA_CURL)
     set(LLAMA_COMMON_EXTRA_LIBS ${LLAMA_COMMON_EXTRA_LIBS} ${CURL_LIBRARY})
 endif ()
 
+# Use ffmpeg to load video files
+if (LLAMA_FFMPEG)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(FFMPEG REQUIRED
+        libavformat
+        libavcodec
+        libavutil
+    )
+    add_definitions(-DLLAMA_USE_FFMPEG)
+    include_directories(${FFMPEG_INCLUDE_DIRS})
+    set(LLAMA_COMMON_EXTRA_LIBS ${LLAMA_COMMON_EXTRA_LIBS} ${FFMPEG_LIBRARIES})
+endif ()
+
 target_include_directories(${TARGET} PUBLIC .)
 target_compile_features   (${TARGET} PUBLIC cxx_std_11)
 target_link_libraries     (${TARGET} PRIVATE ${LLAMA_COMMON_EXTRA_LIBS} PUBLIC llama Threads::Threads)

--- a/examples/llava/minicpmv-cli.cpp
+++ b/examples/llava/minicpmv-cli.cpp
@@ -9,12 +9,14 @@
 #include <cstdlib>
 #include <vector>
 
+#if defined(LLAMA_USE_FFMPEG)
 extern "C" {
     #include <libavcodec/avcodec.h>
     #include <libavformat/avformat.h>
     #include <libavutil/imgutils.h>
     #include <libswscale/swscale.h>
 }
+#endif // LLAMA_USE_FFMPEG
 
 struct llava_context {
     struct clip_ctx * ctx_clip = NULL;
@@ -27,6 +29,8 @@ struct clip_image_u8 {
     int ny;
     std::vector<uint8_t> buf;
 };
+
+#if defined(LLAMA_USE_FFMPEG)
 
 static std::vector<clip_image_u8 *> extract_frames(const std::string& video_path, const int frame_num) {
     AVFormatContext* format_ctx = nullptr;
@@ -155,6 +159,15 @@ static std::vector<clip_image_u8 *> extract_frames(const std::string& video_path
 
     return frames;
 }
+
+#else
+
+static std::vector<clip_image_u8 *> extract_frames(const std::string& video_path, const int frame_num) {
+    LOG_TEE("%s: llama.cpp built without ffmpeg, processing video files is not supported.\n", __func__);
+    return {};
+}
+
+#endif // LLAMA_USE_FFMPEG
 
 static void show_additional_info(int /*argc*/, char ** argv) {
     LOG_TEE("\n example usage: %s -m <llava-v1.5-7b/ggml-model-q5_k.gguf> --mmproj <llava-v1.5-7b/mmproj-model-f16.gguf> [--video <path/to/an/video.mp4>] [--image <path/to/an/image.jpg>] [--image <path/to/another/image.jpg>] [--temp 0.1] [-p \"describe the image in detail.\"]\n", argv[0]);

--- a/examples/llava/minicpmv-cli.cpp
+++ b/examples/llava/minicpmv-cli.cpp
@@ -163,7 +163,7 @@ static std::vector<clip_image_u8 *> extract_frames(const std::string& video_path
 #else
 
 static std::vector<clip_image_u8 *> extract_frames(const std::string& video_path, const int frame_num) {
-    LOG_TEE("%s: llama.cpp built without ffmpeg, processing video files is not supported.\n", __func__);
+    LOG_TEE("%s: llama.cpp built without ffmpeg, processing video files is not supported. Please recompile with LLAMA_FFMPEG=1 to add video support.\n", __func__);
     return {};
 }
 


### PR DESCRIPTION
PLEASE NOTE: This is a PR to amend https://github.com/ggerganov/llama.cpp/pull/9165/ to implement [ngxson's suggestion](https://github.com/ggerganov/llama.cpp/pull/9165#discussion_r1732489542) to make the ffmpeg dependency optional.

This moves the ffmpeg dependency to live behind a compiler flag that can be enabled optionally by setting LLAMA_FFMPEG=1 in call to make.

If you just build without this option, then attempting to load a video file displays a message to the user:

```
extract_frames: llama.cpp built without ffmpeg, processing video files is not supported.
```

However, one can re-enable video support by adding it as a compiler flag, ex:

`make clean`
`make -j LLAMA_FFMPEG=1`

And then video support works as-expected.

There are still a few rough points with this implementation that may need to be cleaned up -- namely:

* There is are warnings about unused variables when building without ffmpeg:
```

examples/llava/minicpmv-cli.cpp:165:71: warning: unused parameter 'video_path' [-Wunused-parameter]
static std::vector<clip_image_u8 *> extract_frames(const std::string& video_path, const int frame_num) {
                                                                      ^
examples/llava/minicpmv-cli.cpp:165:93: warning: unused parameter 'frame_num' [-Wunused-parameter]
static std::vector<clip_image_u8 *> extract_frames(const std::string& video_path, const int frame_num) {
```

* Generation does not stop if video loading is not supported, but it will simply attempt to continue without the video being there. If the prompt references the video, then the model will hallucinate -- this is not an ideal scenario. Example:

```
llama_kv_cache_init:      Metal KV buffer size =   224.00 MiB
llama_new_context_with_model: KV self size  =  224.00 MiB, K (f16):  112.00 MiB, V (f16):  112.00 MiB
llama_new_context_with_model:        CPU  output buffer size =     0.58 MiB
llama_new_context_with_model:      Metal compute buffer size =   303.22 MiB
llama_new_context_with_model:        CPU compute buffer size =    15.01 MiB
llama_new_context_with_model: graph nodes  = 986
llama_new_context_with_model: graph splits = 2
extract_frames: llama.cpp built without ffmpeg, processing video files is not supported.
minicpmv_version: 3
<user>What is in the video?
<assistant>The video contains a sequence of images showing a car driving on a road. The car appears to be moving from left to right across the frame, and there are no other vehicles or people visible in the immediate surroundings. The background consists of a blurred landscape with trees and vegetation, suggesting that the car is traveling through a rural or suburban area.

The first image shows the front-left side of the car, while the subsequent images provide a more frontal view as the car continues to move forward. There are no significant changes in the environment or any additional objects introduced throughout the sequence. The overall impression is of a quiet and peaceful drive on a clear day.%
```

* The way I implemented this adds the ffmpeg dependencies as a flag to EVERY binary built in the system, which may be good (as eventually video multimodality is supported by more and more models), but it may just be clutter for the time being. I have mixed feelings on this point.

Overall, I think this is still an improvement, since llama.cpp should not require a dependency on ffmpeg / pkg-config, and this nicely separates that out.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High

